### PR TITLE
Fix PCE Mouse on multitap

### DIFF
--- a/PCEMouse/src/clock.pio
+++ b/PCEMouse/src/clock.pio
@@ -1,5 +1,5 @@
 ;
-; By Dave Shadoff (c) 2021
+; By Dave Shadoff (c) 2021, 2022
 ;
 ;
 ; Interfacing for a PC Engine mouse
@@ -10,24 +10,28 @@
 ;    - Take a word from FIFO, and output a nybble based on {sequence within poll cycle, state of SEL line}
 ;
 ; 2) Clocked input, which monitors the CLR joypad line for
-;    low->high transitions, to set the state counter
+;    high->low transitions, to set the state counter
+;    
 ; 
 ; This file (clock.pio) implements State Machine #2
 ; -------------------------------------------------
 ;
+; NOTE: when connected directly to PC Engine, the clock signal is a very short low-high-low signal;
+;       but when connected via multitap, the clock signal is always high except when that port is active
+;
 
 .program clock
 
-; Sample bits using an external clock (rising edge), and push groups of bits into the RX FIFO.
+; Sample bits using an external clock (falling edge), and push groups of bits into the RX FIFO.
 ; - IN pin 0 is the clock pin (and also the pin with data)
 ; - Autopush is enabled, threshold 1
 ;
-; This program samples data with each rising clock edge,
+; This program samples data with each falling clock edge,
 ;  with no wait for data to settle
 
 clklp:
-    wait 0 pin 0
     wait 1 pin 0
+    wait 0 pin 0
     in pins, 1
     jmp clklp
 


### PR DESCRIPTION
Direct connection hs a very short CLR pulse, and the CLR signal remains low for the majority of the time. It was for this reason that the clock.pio program waited for the positive edge (0->1) of the CLR signal.

However, on the multitap, the CLR signal is on all of the time except when that particular port is enabled. For this reason, the clock.pio needs to be changed to wait for the negative edge (1->0)  of the CLR signal.