### PR TITLE
Improve detection in multitap by Lemmings ( #2 )

### DIFF
--- a/PCEMouse/src/plex.pio
+++ b/PCEMouse/src/plex.pio
@@ -11,11 +11,11 @@
 ;       to be sent to the OUT pins, based on:
 ;       a) the value of the input SEL line (from joypad)
 ;       b) a counter sent in the ISR, baed on the number of
-;          times the CLR joypad line has gone high in a
+;          times the CLR joypad line has gone low in a
 ;          scanning cycle
 ;
 ; 2) Clocked input, which monitors the CLR joypad line for
-;    low->high transitions, to set the state counter
+;    high->low transitions, to set the state counter
 ; 
 ;
 ; This implements state machine #1


### PR DESCRIPTION
These improvements change Lemmings detection in the multitap from 0% to roughly 80% of the time (still 100% on direct connection):
- Reduce timeout for repeating sequence
- wait for SEL signal transition before updating output word
- startup delay (2 seconds) to allow electronics to settle into normal operation before connecting to software